### PR TITLE
Added json error handling

### DIFF
--- a/api/src/main/java/com/gourmetdelights/api/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/gourmetdelights/api/exception/GlobalExceptionHandler.java
@@ -8,12 +8,20 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+
 @ControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ResourceNotFoundException.class)
-    public ResponseEntity<?> ResourceNotFoundException(Exception exception, WebRequest request) {
+    public ResponseEntity<?> resourceNotFoundException(Exception exception, WebRequest request) {
         ErrorDetails details = new ErrorDetails(new Date(), exception.getMessage(), request.getDescription(false));
         return new ResponseEntity<>(details, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(InvalidFormatException.class)
+    public ResponseEntity<?> invalidFormatException(Exception exception, WebRequest request) {
+        ErrorDetails details = new ErrorDetails(new Date(), exception.getMessage(), request.getDescription(false));
+        return new ResponseEntity<>(details, HttpStatus.BAD_REQUEST);
     }
 }

--- a/api/src/main/java/com/gourmetdelights/api/exception/ResourceNotFoundException.java
+++ b/api/src/main/java/com/gourmetdelights/api/exception/ResourceNotFoundException.java
@@ -4,7 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 @ResponseStatus(HttpStatus.NOT_FOUND)
-public class ResourceNotFoundException extends RuntimeException{
+public class ResourceNotFoundException extends RuntimeException {
 
     public ResourceNotFoundException(String message) {
         super(message);


### PR DESCRIPTION
When a malformed json is passed in, it will give error in the form of the following: 

HTTP 400
{
  timestamp: 
  message: 
  details: 
}

This is done by adding methods which handle a InvalidFormatException in the GlobalExceptionHandler